### PR TITLE
Remove SHA tag from Docker build tags in CI

### DIFF
--- a/.github/workflows/build-mini.yml
+++ b/.github/workflows/build-mini.yml
@@ -29,7 +29,6 @@ jobs:
           tags: |
             type=ref,event=branch,suffix=-mini
             type=ref,event=pr,suffix=-mini
-            type=sha,suffix=-mini
             type=raw,value=mini,enable={{is_default_branch}}
 
       - name: Login to GHCR


### PR DESCRIPTION
The SHA-based tag with '-mini' suffix was removed from the Docker build tags in the build-mini GitHub Actions workflow. This simplifies the tagging strategy and avoids unnecessary image tags.